### PR TITLE
Fix order of stolen_flags in round scoreboard evaluation

### DIFF
--- a/lib/CS/Model/Score.pm
+++ b/lib/CS/Model/Score.pm
@@ -107,7 +107,7 @@ sub flag_points {
     ->hashes->reduce(sub { ++$b->{round}; $a->{$b->{team_id}}{$b->{service_id}} = $b; $a; }, {});
   my $flags = $db->query('
     select f.data, f.service_id, f.team_id as victim_id, sf.team_id, sf.amount
-    from flags as f join stolen_flags as sf using (data) where sf.round = ?', $r)->hashes;
+    from flags as f join stolen_flags as sf using (data) where sf.round = ? order by sf.ts asc', $r)->hashes;
 
   for my $flag (@$flags) {
     $state->{$flag->{team_id}}{$flag->{service_id}}{amount} += $flag->{amount};


### PR DESCRIPTION
When you calculate flag points change for the round, you get stolen flags from database in random order. This patch fixes flags ordering. 

Invalid order may lead to incorrect scoring.

Example:

* There's 10 teams
* It's the first round, everyone has 10 FP on game start
* During the first round, three events happen:
  1. A steals B's flag
  2. C steals A's flag
  3. D steals A's flag

Expected scoring:
* A gets 10 FP from B
* A gives 10 FP to C
* A gives 10 FP to D
* After Round 1, A has 0 flag points

Actual scoring may be (depends on return order, which is not defined):
* A gives 10 FP to C
* A gives 10 FP to D (but A has no points, so no points are subtracted)
* A gets 10 FP from B
* After Round 1, A has 10 flag points

So, A gets 10 extra flag points.