### PR TITLE
Add support of websockets over HTTPS

### DIFF
--- a/templates/main/index.html.ep
+++ b/templates/main/index.html.ep
@@ -10,7 +10,8 @@
 <script>
   var attempts = 1;
   function create_ws() {
-    var ws = new WebSocket('ws://' + location.host + '<%= url_for('update') %>');
+    var wsproto = location.protocol === 'https:' ? 'wss' : 'ws';
+    var ws = new WebSocket(wsproto + '://' + location.host + '<%= url_for('update') %>');
 
     ws.onopen = function(event) {
       attempts = 1;


### PR DESCRIPTION
Live scoreboard updates is broken when serving via HTTPS, because browser can't load insecure (ws://) resource.

![image](https://user-images.githubusercontent.com/11004619/99374327-83d64400-28d3-11eb-85ab-8ca15241b9ca.png)
