### PR TITLE
Allow to specify team_id in config file

### DIFF
--- a/lib/CS/Command/init_db.pm
+++ b/lib/CS/Command/init_db.pm
@@ -15,6 +15,7 @@ sub run {
       host    => delete $team->{host},
       token   => delete $team->{token}
     };
+    $values->{'id'} = delete $team->{id} if $team->{id};
     my $details = {details => {-json => $team}};
     $db->insert(teams => {%$values, %$details});
   }


### PR DESCRIPTION
This patch allows to specify "id" field in cs.conf. In this case the team will be created in the database with specified id.